### PR TITLE
Use copyFileSync instead of pipe

### DIFF
--- a/install-git-hooks.js
+++ b/install-git-hooks.js
@@ -38,9 +38,7 @@ function copyDir(src, dest) {
 };
 
 function copy(src, dest) {
-  const oldFile = fs.createReadStream(src);
-  const newFile = fs.createWriteStream(dest);
-  oldFile.pipe(newFile);
+  fs.copyFileSync(src, dest);
 };
 
 module.exports = installGitHooks;


### PR DESCRIPTION
When I put hook scripts in `.githooks` with the executable bit enabled, and then ran `npm install`, the copies in `.git/hooks` were not executable (and therefore were not used by git). This change fixed that.