### PR TITLE
Use `prepare` instead of `postinstall` to initialize hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ Create a `.githooks` folder and place hooks inside named corresponding to what t
 runs before a commit and is often used to perform linting. Remember to set the executable flag for hook files on \*NIX systems:
 > chmod +x .githooks/*
 
-Add the following `postinstall` script to package.json:
+Add the following `prepare` script to package.json:
 ```
 "scripts": {
-  "postinstall": "node-git-hooks"
+  "prepare": "node-git-hooks"
 },
 ```
 


### PR DESCRIPTION
`node-git-hooks` is only used as devDependencies, but `postinstall` is also triggered when published package is installed via npm. Thus one should also install `node-git-hooks` in their repository, or the package publisher should include `node-git-hooks` as a dependencies, not devDependencies.

Changing `postinstall` to `prepare` prevent it, since it installs the hooks only when developing the package, not when installing the package via npm.

Refer to the [npm docs](https://docs.npmjs.com/cli/v7/using-npm/scripts#prepare-and-prepublish) for more detail.